### PR TITLE
added support for multiple params. example: Macaw::get('/(:any)/(:any)/(...

### DIFF
--- a/macaw.php
+++ b/macaw.php
@@ -71,7 +71,7 @@ class Macaw
                 if (preg_match('#^' . $route . '$#', $uri, $matched)) {
                     if (self::$methods[$pos] == $method) {
                         $found_route = true;
-                        call_user_func_array(self::$callbacks[$pos], array($matched[1]));
+                        call_user_func_array(self::$callbacks[$pos], $matched);
                     }
                 }
             $pos++;


### PR DESCRIPTION
Allow catching/passing multiple parameters.

<pre>
Macaw::get('/(:any)/(:any)/(:any)', function($slug1, $slug2, $etc){
    echo 'Hello ' . $slug1 . $slug2 . $etc;
});
Macaw::dispatch();
</pre>
