### PR TITLE
remove $_SERVER['PHP_SELF'] prefixing for route defs

### DIFF
--- a/Macaw.php
+++ b/Macaw.php
@@ -35,7 +35,7 @@ class Macaw
     public static function __callstatic($method, $params) 
     {
         
-        $uri = dirname($_SERVER['PHP_SELF']).$params[0];
+        $uri = $params[0];
         $callback = $params[1];
 
         array_push(self::$routes, $uri);


### PR DESCRIPTION
hey @NoahBuscher,

when trying to run Macaw under PHP's built-in server [1], the defined routes were not working either with a default (index.php) or explicit front controller, respectively:

`php -S localhost:9090`
`php -S localhost:9090 routes.php`

after some debugging, it turns out the problem was the auto-prefixing of routes during definition with `$_SERVER['PHP_SELF']` @ https://github.com/NoahBuscher/Macaw/blob/master/Macaw.php#L38

this was causing duplication of route strings. simply dropping the prefixing seems to work there without issues in my limited testing (also with nginx). i do not have an apache or IIS setup to test with those. i did not see tests in the repo, so there's no quick way for me to verify nothing broke, but perhaps look into this pull request or other relevant changes that can fix the issue.

for reference, this is the code that did not work before the change, but worked afterwards:

``` php
require 'vendor/autoload.php';

use \NoahBuscher\Macaw\Macaw;

Macaw::get('/', function() {
    echo 'Hello world!';
});

Macaw::get('/moo/([0-9]{3})/?', function($digs) {
    echo $digs;
});

Macaw::dispatch();
```

with the browser pointed to `http://localhost/moo/123` and `http://localhost/moo/123/`

thanks,
leon

[1] http://www.sitepoint.com/taking-advantage-of-phps-built-in-server/
