### PR TITLE
Update Macaw.php

### DIFF
--- a/Macaw.php
+++ b/Macaw.php
@@ -68,6 +68,8 @@ class Macaw
         $replaces = array_values(static::$patterns);
 
         $found_route = false;
+        
+        self::$routes = str_replace('//', '/', self::$routes);
 
         // check if route is defined without regex
         if (in_array($uri, self::$routes)) {


### PR DESCRIPTION
This solves the double slash problem. (which is essentially solving #26 #33)
![](http://puu.sh/k3HHB/8b4e512e55.png) ![](http://puu.sh/k3HJO/4005baafd1.png)
The array is a print_r from Macaw::$routes