### PR TITLE
changed replace of root route to clean any double slash

### DIFF
--- a/Macaw.php
+++ b/Macaw.php
@@ -57,7 +57,7 @@ class Macaw {
 
     $found_route = false;
 
-    self::$routes = str_replace('//', '/', self::$routes);
+    self::$routes = preg_replace('/\/+/', '/', self::$routes);
 
     // Check if route is defined without regex
     if (in_array($uri, self::$routes)) {


### PR DESCRIPTION
In my case (apache2, php 7) the get(/) route place 3 slashes in the self::$routes array. made it preg_replace to be able to say more than 1.