### PR TITLE
Fix issue #74 to allow both original routing method and new maps function to co-exist

### DIFF
--- a/Macaw.php
+++ b/Macaw.php
@@ -114,7 +114,7 @@ class Macaw {
         }
 
         if (preg_match('#^' . $route . '$#', $uri, $matched)) {
-          if (self::$methods[$pos] == $method || self::$methods[$pos] == 'ANY' || in_array($method, self::$maps[$pos])) {
+          if (self::$methods[$pos] == $method || self::$methods[$pos] == 'ANY' || (!empty(self::$maps[$pos]) && in_array($method, self::$maps[$pos]))) {
             $found_route = true;
 
             // Remove $matched[0] as [1] is the first parameter.


### PR DESCRIPTION
This is a fix for issue #74 that will allow both the original method of adding routes and the new map method to coexist without throwing an error.

Before the fix, using:

Macaw::get('/api/pages/partial/(:num)', 'Mynamespace\API\Pages@getPartial');
Macaw::put('/api/pages/partial/(:num)', 'Mynamespace\API\Pages@updatePartial');

would throw an error with when it tried to evaluate the maps array (which is null if you are not using the map function).

Now it will check to see if the current element of the maps array is not null before trying to evaluate the in_array statement which avoids the error but maintains all the functionality.