### PR TITLE
Increase the root of the route

### DIFF
--- a/Macaw.php
+++ b/Macaw.php
@@ -22,6 +22,7 @@ class Macaw {
       ':all' => '.*'
   );
   public static $error_callback;
+  public static $root;
 
   /**
    * Defines a route w/ callback and method
@@ -59,7 +60,16 @@ class Macaw {
    * Runs the callback for the given request
    */
   public static function dispatch(){
-    $uri = parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH);
+    $uri = rtrim(parse_url($_SERVER['REQUEST_URI'], PHP_URL_PATH), '/');
+    if (!empty(self::$root) && self::$root !== '/') {
+      self::$root = rtrim(self::$root, '/');
+      if (self::$root === $uri) {
+        $uri = '/';
+      } else {
+        // Remove the root directory from uri, remove only the first occurrence
+        $uri = substr_replace($uri, '', strpos($uri, self::$root), strlen(self::$root));
+      }
+    }
     $method = $_SERVER['REQUEST_METHOD'];
 
     $searches = array_keys(static::$patterns);


### PR DESCRIPTION
my English is not very good, I try to describe the problem clearly.

Before changing the source code, I found a problem
access this route `http://localhost/project/hello` normal work,
But this route `http://localhost/project/hello/` does not work, get 404

My project root directory：`http://localhost/project`

index.php
```php
<?php
require 'macaw/Macaw.php';
use NoahBuscher\Macaw\Macaw;

Macaw::get('/project', function () {
    echo 'hello world';
});

Macaw::get('/project/hello', function () {
    echo 'hello';
});
```

Mod:
  line 62
  used `rtrim($uri, '/')`, Resumed work again

&

I like this simple route, I hope it can be used in a multi-level directory.

Add:
  route root

For different use environments, routing functions can be used normally
in the case of multi-site directories. Just set the root directory.

like this:
```php
<?php
require 'macaw/Macaw.php';
use NoahBuscher\Macaw\Macaw;

Macaw::$root = '/project';

Macaw::get('/', function () {
    echo 'hello world';
});

Macaw::get('/hello', function () {
    echo 'hello';
});
```

Fixes #73 